### PR TITLE
set up handlebars engine and rendered homepage

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -1,7 +1,12 @@
 const router = require('express').Router();
 
 router.get('/', async (req, res) => {
-    res.render('homepage');
+    try{
+        // layout: false is a placeholder and should be deleted when we have a handlebars {{{body}}}
+        res.render('homepage', {layout: false});
+    } catch (err) {
+        res.status(500).json(err);
+    }
 });
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -9,6 +9,13 @@ const routes = require('./controllers');
 const app = express();
 const port = process.env.PORT || 3306;
 
+// Set up handlebars engine
+const hbs = exphbs.create();
+
+// Tell express which template engine to use
+app.engine('handlebars', hbs.engine);
+app.set('view engine', 'handlebars');
+
 // Use Express's built-in middleware for json and urlencoded form data
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Added code to server.js to set up the handlebars engine. Also fixed the get method in homeRoutes to make it asynchronous and render the homepage. '{layout: false}' on line 6 can be deleted once we have handlebars code. Right now that line is just allowing us to see the html despite not having any handlebars code.